### PR TITLE
changing incremental to 21.3.0

### DIFF
--- a/schools/requirements.txt
+++ b/schools/requirements.txt
@@ -16,7 +16,7 @@ html5lib==1.1
 hyperlink==20.0.1
 idna==2.10
 IMAPClient==2.1.0
-incremental==17.5.0
+incremental==21.3.0
 itemadapter==0.2.0
 itemloaders==1.0.4
 jmespath==0.10.0


### PR DESCRIPTION
changing due to conflict caused by twisted 22.1.0 requirements. This solves a consistent error when cloning and running multiprocessing code